### PR TITLE
Adding missing folder geth

### DIFF
--- a/scripts/lukso
+++ b/scripts/lukso
@@ -297,6 +297,10 @@ start_pandora() {
   if [[ ! -d "$DATADIR/pandora" ]]; then
     mkdir -p "$DATADIR/pandora"
   fi
+  
+  if [[ ! -d "$DATADIR/pandora/geth" ]]; then
+    mkdir -p "$DATADIR/pandora/geth"
+  fi
 
   pandora --datadir $DATADIR/pandora init /opt/lukso/networks/$NETWORK/config/pandora-genesis.json &>/dev/null
   cp /opt/lukso/networks/"$NETWORK"/config/pandora-nodes.json $DATADIR/pandora/geth/static-nodes.json


### PR DESCRIPTION
In $DATADIR/pandora missing folder geth. I add it. After start the script (->pandora) in Linux, we can see an error "cp: cannot create regular file '/root/.lukso/l15/datadirs/pandora/geth/static-nodes.json': No such file or directory"