### PR TITLE
Fix - Changed dispatch token secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Request network upgrade
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_DISPATCH_TOKEN }}
         run: |
           curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \


### PR DESCRIPTION
Signed-off-by: mxmar <macht4tech@gmail.com>

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

We cannot use standard GITHUB_TOKEN secret to perform `repository_dispatch`. We must use personal GH token for GH API calls.

**Which issues(s) does this PR fix?**

No task/issue was made.

**Other notes for review**

None