### PR TITLE
Fix "command not found" for MacOS"

### DIFF
--- a/scripts/install-unix.sh
+++ b/scripts/install-unix.sh
@@ -31,6 +31,10 @@ if [[ $PLATFORM == "Linux" ]]; then
   unzip -y;
 fi
 
+if [[ ! -d "/usr/local/bin" ]]; then
+  sudo mkdir -p /usr/local/bin;
+fi
+
 download() {
   URL="$1";
   LOCATION="$2";


### PR DESCRIPTION
A few people in the discord running macOS have had an issue with `lukso` not being symbolic linked to /usr/local/bin because the directory didn't exist. As a result they get "command not found" running the lukso command.

I've created an if statement to check if the directory exists and creates one if it doesn't, this seems to have solved the issue for everyone i've helped on discord.

As far as I understand, /usr/local/bin is in PATH by default so no issue there.