### PR TITLE
Added sleep step to GH actions for develop branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,10 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+      - name: Sleep for 10 seconds
+        run: sleep 20s
+        shell: bash
+
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
-      - name: Sleep for 10 seconds
+      - name: Sleep
         run: sleep 20s
         shell: bash
 


### PR DESCRIPTION
This should preserve tag race condition for goreleaser in develop branch GH action.